### PR TITLE
Add Go multi-tenant event feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# technical-assignment
-technical-assignment
+# Real-Time Multi-Tenant Event Feed
+
+This project provides a simple real-time event broadcasting system implemented in Go.
+
+## Features
+
+- WebSocket server with tenant isolation
+- REST endpoint `POST /events` for publishing events
+- Basic HTML frontend in `frontend/` demonstrating usage
+- In-memory storage only
+
+## Running
+
+```
+cd backend
+go run .
+```
+
+Open `frontend/index.html` in your browser. Use two browser windows with different tenants to verify that events are isolated.
+
+## Testing
+
+```
+cd backend
+go test ./...
+```

--- a/backend/event.go
+++ b/backend/event.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+)
+
+// Event represents a single event message
+type Event struct {
+	ID        string    `json:"id"`
+	TenantID  string    `json:"tenant_id"`
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// newEvent creates a new event with generated ID and current timestamp
+func newEvent(tenantID, message string) Event {
+	return Event{
+		ID:        generateID(),
+		TenantID:  tenantID,
+		Message:   message,
+		Timestamp: time.Now().UTC(),
+	}
+}
+
+func generateID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}

--- a/backend/eventhub.go
+++ b/backend/eventhub.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"sync"
+)
+
+// Conn defines minimal methods for a websocket connection
+// real websocket or mock must implement this interface
+// WriteJSON should serialize v as JSON and send
+// Close closes the connection
+// in our simple implementation, only text frames with JSON will be used
+
+type Conn interface {
+	WriteJSON(v interface{}) error
+	Close() error
+}
+
+// TenantHub manages events and connections for a single tenant
+type TenantHub struct {
+	events      []Event
+	connections map[Conn]bool
+	mu          sync.Mutex
+}
+
+func newTenantHub() *TenantHub {
+	return &TenantHub{
+		events:      make([]Event, 0),
+		connections: make(map[Conn]bool),
+	}
+}
+
+// addEvent stores the event and broadcasts it
+func (h *TenantHub) addEvent(e Event) {
+	h.mu.Lock()
+	h.events = append(h.events, e)
+	for c := range h.connections {
+		_ = c.WriteJSON(e)
+	}
+	h.mu.Unlock()
+}
+
+// addConn registers a new connection
+func (h *TenantHub) addConn(c Conn) {
+	h.mu.Lock()
+	h.connections[c] = true
+	h.mu.Unlock()
+}
+
+// removeConn removes a connection
+func (h *TenantHub) removeConn(c Conn) {
+	h.mu.Lock()
+	if _, ok := h.connections[c]; ok {
+		delete(h.connections, c)
+		_ = c.Close()
+	}
+	h.mu.Unlock()
+}
+
+// EventHub manages tenants
+type EventHub struct {
+	tenants map[string]*TenantHub
+	mu      sync.Mutex
+}
+
+func newEventHub() *EventHub {
+	return &EventHub{tenants: make(map[string]*TenantHub)}
+}
+
+// postEvent creates and stores event for tenant
+func (h *EventHub) postEvent(tenantID, message string) Event {
+	h.mu.Lock()
+	tenant := h.ensureTenant(tenantID)
+	h.mu.Unlock()
+	e := newEvent(tenantID, message)
+	tenant.addEvent(e)
+	return e
+}
+
+func (h *EventHub) ensureTenant(id string) *TenantHub {
+	if t, ok := h.tenants[id]; ok {
+		return t
+	}
+	t := newTenantHub()
+	h.tenants[id] = t
+	return t
+}
+
+// registerConn registers connection to tenant
+func (h *EventHub) registerConn(tenantID string, c Conn) {
+	h.mu.Lock()
+	tenant := h.ensureTenant(tenantID)
+	h.mu.Unlock()
+	tenant.addConn(c)
+}
+
+// unregisterConn removes connection from tenant
+func (h *EventHub) unregisterConn(tenantID string, c Conn) {
+	h.mu.Lock()
+	tenant := h.tenants[tenantID]
+	h.mu.Unlock()
+	if tenant != nil {
+		tenant.removeConn(c)
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module eventfeed
+
+go 1.24.3

--- a/backend/hub_test.go
+++ b/backend/hub_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+)
+
+// fakeConn records written messages
+
+type fakeConn struct {
+	mu   sync.Mutex
+	msgs []Event
+}
+
+func (f *fakeConn) WriteJSON(v interface{}) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var e Event
+	b, _ := json.Marshal(v)
+	json.Unmarshal(b, &e)
+	f.msgs = append(f.msgs, e)
+	return nil
+}
+
+func (f *fakeConn) Close() error { return nil }
+
+func TestTenantIsolation(t *testing.T) {
+	hub := newEventHub()
+	cA := &fakeConn{}
+	cB := &fakeConn{}
+
+	hub.registerConn("tenantA", cA)
+	hub.registerConn("tenantB", cB)
+
+	hub.postEvent("tenantA", "hello A")
+	hub.postEvent("tenantB", "hello B")
+
+	if len(cA.msgs) != 1 || cA.msgs[0].Message != "hello A" {
+		t.Fatalf("tenant A should receive its event")
+	}
+	if len(cB.msgs) != 1 || cB.msgs[0].Message != "hello B" {
+		t.Fatalf("tenant B should receive its event")
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+func main() {
+	hub := newEventHub()
+	http.HandleFunc("/ws", serveWS(hub))
+	http.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		tenantID := r.Header.Get("X-Tenant-ID")
+		if tenantID == "" {
+			http.Error(w, "missing tenant header", http.StatusBadRequest)
+			return
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		var req struct {
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		e := hub.postEvent(tenantID, req.Message)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(e)
+	})
+	log.Println("listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/backend/ws.go
+++ b/backend/ws.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const magicKey = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+// wsConn implements minimal WebSocket connection for server->client messages
+
+type wsConn struct {
+	c  net.Conn
+	mu sync.Mutex
+}
+
+func newWSConn(c net.Conn) *wsConn {
+	return &wsConn{c: c}
+}
+
+func (w *wsConn) WriteJSON(v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return w.writeFrame(1, data) // text frame opcode=1
+}
+
+func (w *wsConn) writeFrame(opcode byte, payload []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	header := []byte{0x80 | opcode, 0}
+	l := len(payload)
+	if l < 126 {
+		header[1] = byte(l)
+	} else if l <= 65535 {
+		header[1] = 126
+		ext := make([]byte, 2)
+		binary.BigEndian.PutUint16(ext, uint16(l))
+		header = append(header, ext...)
+	} else {
+		header[1] = 127
+		ext := make([]byte, 8)
+		binary.BigEndian.PutUint64(ext, uint64(l))
+		header = append(header, ext...)
+	}
+	if _, err := w.c.Write(header); err != nil {
+		return err
+	}
+	_, err := w.c.Write(payload)
+	return err
+}
+
+func (w *wsConn) readLoop(onClose func()) {
+	buf := make([]byte, 2)
+	for {
+		if _, err := io.ReadFull(w.c, buf); err != nil {
+			break
+		}
+		fin := buf[0]&0x80 != 0
+		opcode := buf[0] & 0x0F
+		masked := buf[1]&0x80 != 0
+		length := int(buf[1] & 0x7F)
+		if length == 126 {
+			ext := make([]byte, 2)
+			if _, err := io.ReadFull(w.c, ext); err != nil {
+				break
+			}
+			length = int(binary.BigEndian.Uint16(ext))
+		} else if length == 127 {
+			ext := make([]byte, 8)
+			if _, err := io.ReadFull(w.c, ext); err != nil {
+				break
+			}
+			length = int(binary.BigEndian.Uint64(ext))
+		}
+		maskKey := make([]byte, 4)
+		if masked {
+			if _, err := io.ReadFull(w.c, maskKey); err != nil {
+				break
+			}
+		}
+		payload := make([]byte, length)
+		if _, err := io.ReadFull(w.c, payload); err != nil {
+			break
+		}
+		if masked {
+			for i := range payload {
+				payload[i] ^= maskKey[i%4]
+			}
+		}
+		if opcode == 8 { // close frame
+			break
+		}
+		if !fin {
+			// ignore fragmented frames for simplicity
+			continue
+		}
+		// ignore payload for now
+	}
+	onClose()
+}
+
+func (w *wsConn) Close() error {
+	return w.c.Close()
+}
+
+// serveWS handles WebSocket upgrade and connection registration
+func serveWS(hub *EventHub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tenantID := r.URL.Query().Get("tenant")
+		if tenantID == "" {
+			http.Error(w, "missing tenant", http.StatusBadRequest)
+			return
+		}
+		if !headerContains(r.Header, "Connection", "upgrade") ||
+			!headerContains(r.Header, "Upgrade", "websocket") {
+			http.Error(w, "not websocket", http.StatusBadRequest)
+			return
+		}
+		key := r.Header.Get("Sec-WebSocket-Key")
+		if key == "" {
+			http.Error(w, "missing key", http.StatusBadRequest)
+			return
+		}
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "cannot hijack", http.StatusInternalServerError)
+			return
+		}
+		netConn, buf, err := hijacker.Hijack()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if buf.Reader.Buffered() > 0 {
+			log.Println("unexpected buffered data")
+		}
+		accept := computeAcceptKey(key)
+		resp := "HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: websocket\r\n" +
+			"Connection: Upgrade\r\n" +
+			"Sec-WebSocket-Accept: " + accept + "\r\n\r\n"
+		if _, err := netConn.Write([]byte(resp)); err != nil {
+			netConn.Close()
+			return
+		}
+		ws := newWSConn(netConn)
+		hub.registerConn(tenantID, ws)
+		go ws.readLoop(func() {
+			hub.unregisterConn(tenantID, ws)
+		})
+	}
+}
+
+func computeAcceptKey(key string) string {
+	h := sha1.New()
+	h.Write([]byte(key + magicKey))
+	sum := h.Sum(nil)
+	return base64.StdEncoding.EncodeToString(sum)
+}
+
+func headerContains(h http.Header, name, value string) bool {
+	for _, v := range h.Values(name) {
+		if strings.EqualFold(strings.TrimSpace(v), value) {
+			return true
+		}
+	}
+	return false
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Event Feed</title>
+<style>
+#events { border: 1px solid #ccc; height: 200px; overflow-y: scroll; padding: 5px; }
+</style>
+</head>
+<body>
+<label>Tenant:
+<select id="tenant">
+<option value="tenantA">Tenant A</option>
+<option value="tenantB">Tenant B</option>
+</select>
+</label>
+<button id="connect">Connect</button>
+<div id="status"></div>
+<ul id="events"></ul>
+<form id="eventForm">
+<input type="text" id="message" placeholder="message" required />
+<button type="submit">Send</button>
+</form>
+<script>
+let ws;
+let tenant;
+
+document.getElementById('connect').onclick = () => {
+  tenant = document.getElementById('tenant').value;
+  ws = new WebSocket(`ws://${location.host}/ws?tenant=` + tenant);
+  ws.onmessage = e => {
+    const ev = JSON.parse(e.data);
+    const li = document.createElement('li');
+    li.textContent = `${ev.timestamp} - ${ev.message}`;
+    document.getElementById('events').appendChild(li);
+  };
+  ws.onopen = () => { document.getElementById('status').textContent = 'connected'; };
+  ws.onclose = () => { document.getElementById('status').textContent = 'closed'; };
+};
+
+document.getElementById('eventForm').onsubmit = (e) => {
+  e.preventDefault();
+  const message = document.getElementById('message').value;
+  fetch('/events', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json', 'X-Tenant-ID': tenant},
+    body: JSON.stringify({message})
+  });
+  document.getElementById('message').value = '';
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement minimal WebSocket server and REST API in Go
- broadcast events only to clients of the same tenant
- add simple HTML frontend for two test tenants
- provide unit test for tenant isolation
- update project README with usage instructions

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b77e57d388330811459b8dfea0b48