### PR TITLE
Serve frontend via file server

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cd backend
 go run .
 ```
 
-Open `frontend/index.html` in your browser. Use two browser windows with different tenants to verify that events are isolated.
+Navigate to `http://localhost:8080` in your browser. Use two browser windows with different tenants to verify that events are isolated.
 
 ## Testing
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -5,10 +5,15 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"path/filepath"
 )
 
 func main() {
 	hub := newEventHub()
+	frontendDir := filepath.Join("..", "frontend")
+	fs := http.FileServer(http.Dir(frontendDir))
+	http.Handle("/static/", http.StripPrefix("/static/", fs))
+	http.Handle("/", fs)
 	http.HandleFunc("/ws", serveWS(hub))
 	http.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {


### PR DESCRIPTION
## Summary
- add a file server to main.go so the backend serves the frontend directory
- expose the static site on `/` and `/static/`
- update README with local access instructions

## Testing
- `cd backend && go test ./... && cd ..`

------
https://chatgpt.com/codex/tasks/task_e_688b7ac5eb1483309051c1715f7fd947