### PR TITLE
Limit message history in UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,6 +24,8 @@
 <script>
 let ws;
 let tenant;
+const MAX_EVENTS = 100;
+const eventsList = document.getElementById('events');
 
 document.getElementById('connect').onclick = () => {
   tenant = document.getElementById('tenant').value;
@@ -32,7 +34,10 @@ document.getElementById('connect').onclick = () => {
     const ev = JSON.parse(e.data);
     const li = document.createElement('li');
     li.textContent = `${ev.timestamp} - ${ev.message}`;
-    document.getElementById('events').appendChild(li);
+    eventsList.appendChild(li);
+    if (eventsList.children.length > MAX_EVENTS) {
+      eventsList.removeChild(eventsList.firstChild);
+    }
   };
   ws.onopen = () => { document.getElementById('status').textContent = 'connected'; };
   ws.onclose = () => { document.getElementById('status').textContent = 'closed'; };


### PR DESCRIPTION
## Summary
- add a constant maximum number of messages
- trim oldest message when the list exceeds the limit

## Testing
- `go test ./backend/...`

------
https://chatgpt.com/codex/tasks/task_e_688b7fedc5c88330b78582d1894e3f92