### PR TITLE
Add frontend section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ cd backend
 go run .
 ```
 
-Navigate to `http://localhost:8080` in your browser. Use two browser windows with different tenants to verify that events are isolated.
+## Frontend
+
+Visiting <http://localhost:8080> serves `frontend/index.html`. Open two browser windows, select different tenants in each, and verify that their events remain isolated.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- update README with a new **Frontend** section
- explain that visiting `http://localhost:8080` serves `frontend/index.html`
- describe using two browser windows with different tenants to verify isolation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b866a9b0883309c939d228e0c3b6c