### PR TITLE
Add benchmark for EventHub postEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ Navigate to `http://localhost:8080` in your browser. Use two browser windows wit
 cd backend
 go test ./...
 ```
+
+## Benchmarking
+
+Run the benchmark to measure the performance of posting events:
+
+```
+cd backend
+go test -bench BenchmarkPostEvent -benchmem
+```

--- a/backend/hub_test.go
+++ b/backend/hub_test.go
@@ -81,3 +81,14 @@ func TestFailingConnectionRemoval(t *testing.T) {
 		t.Fatalf("expected log message for write failure")
 	}
 }
+func BenchmarkPostEvent(b *testing.B) {
+	hub := newEventHub()
+	tenantID := "benchTenant"
+	for i := 0; i < 5; i++ {
+		hub.registerConn(tenantID, &fakeConn{})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hub.postEvent(tenantID, "msg")
+	}
+}


### PR DESCRIPTION
## Summary
- add `BenchmarkPostEvent` to measure `EventHub.postEvent` throughput
- document how to run the benchmark in `README.md`

## Testing
- `go test ./...`
- `go test -bench BenchmarkPostEvent -benchmem`


------
https://chatgpt.com/codex/tasks/task_e_688b86625034833091a6db9fbc48a286