### PR TITLE
Add BenchmarkPostEvent with alloc reporting

### DIFF
--- a/backend/hub_test.go
+++ b/backend/hub_test.go
@@ -84,10 +84,10 @@ func TestFailingConnectionRemoval(t *testing.T) {
 }
 
 func TestEventHistoryLimit(t *testing.T) {
-	hub := newTenantHub()
-	for i := 0; i < maxEvents+10; i++ {
-		hub.addEvent(Event{TenantID: "t1", Message: fmt.Sprintf("%d", i)})
-	}
+        hub := newTenantHub()
+        for i := 0; i < maxEvents+10; i++ {
+                hub.addEvent(Event{TenantID: "t1", Message: fmt.Sprintf("%d", i)})
+        }
 	hub.mu.Lock()
 	count := len(hub.events)
 	first := hub.events[0].Message
@@ -99,7 +99,16 @@ func TestEventHistoryLimit(t *testing.T) {
 	if first != "10" {
 		t.Fatalf("expected oldest message to be '10', got %s", first)
 	}
-	if last != fmt.Sprintf("%d", maxEvents+9) {
-		t.Fatalf("expected last message to be %d, got %s", maxEvents+9, last)
-	}
+        if last != fmt.Sprintf("%d", maxEvents+9) {
+                t.Fatalf("expected last message to be %d, got %s", maxEvents+9, last)
+        }
+}
+
+func BenchmarkPostEvent(b *testing.B) {
+        hub := newEventHub()
+        b.ReportAllocs()
+        b.ResetTimer()
+        for i := 0; i < b.N; i++ {
+                hub.postEvent("bench", "msg")
+        }
 }


### PR DESCRIPTION
## Summary
- add benchmark for posting events and report allocations

## Testing
- `go test -bench BenchmarkPostEvent -benchmem`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688b8a0dd60083308338b858ad67f882