### PR TITLE
Add example POST response in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ $ go run .
 2025/07/31 17:44:53.654321 UTC tenant tenantA: event posted: hello (took 200µs)
 ```
 
+POSTing a new event responds with the stored event in JSON:
+
+```json
+{
+  "id": "8a9f6e2c1b2d3e4f5a6b7c8d9e0f1a2b",
+  "tenant_id": "tenantA",
+  "message": "hello",
+  "timestamp": "2025-07-31T17:44:53.654321Z"
+}
+```
+The timestamp follows the same format printed in the log lines above and only
+the `HH:MM:SS` portion is shown in the UI, as in the following example:
+
 The frontend lists each event with a local timestamp:
 
 ```


### PR DESCRIPTION
## Summary
- show a sample JSON response for `POST /events`
- mention that the timestamp matches log output and only the time portion is shown in the UI

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b964a87448330a94d9f44c06997c2