### PR TITLE
Fix elapsed time tracking during event broadcast

### DIFF
--- a/backend/eventhub.go
+++ b/backend/eventhub.go
@@ -47,9 +47,6 @@ func (h *TenantHub) addEvent(e Event) Event {
 	for c := range h.connections {
 		conns = append(conns, c)
 	}
-	elapsed := time.Since(start).String()
-	h.events[idx].Elapsed = elapsed
-	e.Elapsed = elapsed
 	h.mu.Unlock()
 
 	for _, c := range conns {
@@ -63,6 +60,13 @@ func (h *TenantHub) addEvent(e Event) Event {
 			}
 		}
 	}
+
+	elapsed := time.Since(start).String()
+	h.mu.Lock()
+	h.events[idx].Elapsed = elapsed
+	h.mu.Unlock()
+	e.Elapsed = elapsed
+
 	return e
 }
 


### PR DESCRIPTION
## Summary
- ensure event broadcasting time includes sending to clients
- update hub's stored event with final elapsed duration

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b9bf9cb6c83308cf02f5a469083ed