### PR TITLE
Initialize TenantHub events slice with capacity

### DIFF
--- a/backend/eventhub.go
+++ b/backend/eventhub.go
@@ -28,7 +28,7 @@ type TenantHub struct {
 
 func newTenantHub() *TenantHub {
 	return &TenantHub{
-		events:      make([]Event, 0),
+		events:      make([]Event, 0, maxEvents),
 		connections: make(map[Conn]bool),
 	}
 }


### PR DESCRIPTION
## Summary
- optimize TenantHub event storage by setting initial slice capacity

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b9bfdb8608330bfee56d8eae4b973