### PR TITLE
Fix example timestamp format

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ POSTing a new event responds with the stored event in JSON:
   "id": "8a9f6e2c1b2d3e4f5a6b7c8d9e0f1a2b",
   "tenant_id": "tenantA",
   "message": "hello",
-  "timestamp": "2025-07-31T17:44:53.654321Z",
+  "timestamp": "2025-07-31T17:44:53Z",
   "elapsed": "200µs"
 }
 ```


### PR DESCRIPTION
## Summary
- update the example JSON response timestamp to omit fractional seconds

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b9ed698348330a6ec003794cd2649