### PR TITLE
Add reconnect cleanup for frontend WebSocket

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -83,9 +83,10 @@
       const MAX_EVENTS = 100;
       const eventsList = document.getElementById("events");
 
-      document.getElementById("connect").onclick = () => {
-        tenant = document.getElementById("tenant").value;
-        ws = new WebSocket(`ws://${location.host}/ws?tenant=` + tenant);
+        document.getElementById("connect").onclick = () => {
+          if (ws) ws.close();
+          tenant = document.getElementById("tenant").value;
+          ws = new WebSocket(`ws://${location.host}/ws?tenant=` + tenant);
         ws.onmessage = (e) => {
           const ev = JSON.parse(e.data);
           const li = document.createElement("li");


### PR DESCRIPTION
## Summary
- close old socket before reconnecting to keep a single WebSocket

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b9edc8e7c83308bed8caa08996296