### PR TITLE
Update addEvent comment

### DIFF
--- a/backend/eventhub.go
+++ b/backend/eventhub.go
@@ -33,7 +33,7 @@ func newTenantHub() *TenantHub {
 	}
 }
 
-// addEvent stores the event and broadcasts it
+// addEvent stores the event, broadcasts it, and returns the stored event with the Elapsed field populated
 func (h *TenantHub) addEvent(e Event) Event {
 	start := time.Now()
 	h.mu.Lock()


### PR DESCRIPTION
## Summary
- clarify that `TenantHub.addEvent` returns the stored event with the `Elapsed` field populated

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b9ee9029c8330af387853b488ec4a