### PR TITLE
Add elapsed field verification tests

### DIFF
--- a/backend/hub_test.go
+++ b/backend/hub_test.go
@@ -104,6 +104,24 @@ func TestEventHistoryLimit(t *testing.T) {
 	}
 }
 
+func TestPostEventSetsElapsed(t *testing.T) {
+	hub := newEventHub()
+	e := hub.postEvent("tenant1", "msg")
+	if e.Elapsed == "" {
+		t.Fatalf("expected elapsed to be set")
+	}
+
+	hub.mu.Lock()
+	stored := hub.tenants["tenant1"].events[0].Elapsed
+	hub.mu.Unlock()
+	if stored == "" {
+		t.Fatalf("stored event should have elapsed set")
+	}
+	if stored != e.Elapsed {
+		t.Fatalf("elapsed mismatch: %s vs %s", stored, e.Elapsed)
+	}
+}
+
 func BenchmarkPostEvent(b *testing.B) {
 	hub := newEventHub()
 	b.ReportAllocs()

--- a/backend/server_test.go
+++ b/backend/server_test.go
@@ -171,9 +171,15 @@ func TestEventsEndpoint(t *testing.T) {
 	if e1.TenantID != "tenant1" || e1.Message != "hello1" || e1.ID == "" || e1.Timestamp.IsZero() {
 		t.Fatalf("invalid event %+v", e1)
 	}
+	if e1.Elapsed == "" {
+		t.Fatalf("expected elapsed to be set")
+	}
 	e2 := postEvent(t, client, srv.URL, "tenant2", "hello2")
 	if e2.TenantID != "tenant2" || e2.Message != "hello2" {
 		t.Fatalf("invalid event %+v", e2)
+	}
+	if e2.Elapsed == "" {
+		t.Fatalf("expected elapsed to be set")
 	}
 }
 


### PR DESCRIPTION
## Summary
- validate `elapsed` is populated in `TestEventsEndpoint`
- add `TestPostEventSetsElapsed` to ensure hub stores elapsed duration

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688b9eec56f88330ad2d0507871f39de