### PR TITLE
Add elapsed time to UI logs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,29 @@
+name: Go CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+      - name: Check formatting
+        run: |
+          files=$(gofmt -l $(find . -name '*.go' -not -path './vendor/*'))
+          if [ -n "$files" ]; then
+            echo "The following files need gofmt:" >&2
+            echo "$files" >&2
+            exit 1
+          fi
+      - name: Run tests
+        run: |
+          cd backend
+          go test ./...

--- a/README.md
+++ b/README.md
@@ -64,16 +64,18 @@ POSTing a new event responds with the stored event in JSON:
   "id": "8a9f6e2c1b2d3e4f5a6b7c8d9e0f1a2b",
   "tenant_id": "tenantA",
   "message": "hello",
-  "timestamp": "2025-07-31T17:44:53.654321Z"
+  "timestamp": "2025-07-31T17:44:53.654321Z",
+  "elapsed": "200µs"
 }
 ```
 The timestamp follows the same format printed in the log lines above and only
 the `HH:MM:SS` portion is shown in the UI, as in the following example:
 
-The frontend lists each event with a local timestamp:
+The frontend lists each event with a local timestamp and the time it took for the
+server to process the event:
 
 ```
-17:44:53 - hello
+17:44:53 - hello (took 200µs)
 ```
 
 ## Testing

--- a/backend/event.go
+++ b/backend/event.go
@@ -13,6 +13,7 @@ type Event struct {
 	TenantID  string    `json:"tenant_id"`
 	Message   string    `json:"message"`
 	Timestamp time.Time `json:"timestamp"`
+	Elapsed   string    `json:"elapsed"`
 }
 
 // newEvent creates a new event with generated ID and current timestamp

--- a/backend/hub_test.go
+++ b/backend/hub_test.go
@@ -67,7 +67,7 @@ func TestFailingConnectionRemoval(t *testing.T) {
 	defer log.SetOutput(orig)
 
 	hub.addConn(c)
-	hub.addEvent(Event{TenantID: "t1"})
+	_ = hub.addEvent(Event{TenantID: "t1"})
 
 	hub.mu.Lock()
 	_, exists := hub.connections[c]
@@ -84,10 +84,10 @@ func TestFailingConnectionRemoval(t *testing.T) {
 }
 
 func TestEventHistoryLimit(t *testing.T) {
-        hub := newTenantHub()
-        for i := 0; i < maxEvents+10; i++ {
-                hub.addEvent(Event{TenantID: "t1", Message: fmt.Sprintf("%d", i)})
-        }
+	hub := newTenantHub()
+	for i := 0; i < maxEvents+10; i++ {
+		_ = hub.addEvent(Event{TenantID: "t1", Message: fmt.Sprintf("%d", i)})
+	}
 	hub.mu.Lock()
 	count := len(hub.events)
 	first := hub.events[0].Message
@@ -99,16 +99,16 @@ func TestEventHistoryLimit(t *testing.T) {
 	if first != "10" {
 		t.Fatalf("expected oldest message to be '10', got %s", first)
 	}
-        if last != fmt.Sprintf("%d", maxEvents+9) {
-                t.Fatalf("expected last message to be %d, got %s", maxEvents+9, last)
-        }
+	if last != fmt.Sprintf("%d", maxEvents+9) {
+		t.Fatalf("expected last message to be %d, got %s", maxEvents+9, last)
+	}
 }
 
 func BenchmarkPostEvent(b *testing.B) {
-        hub := newEventHub()
-        b.ReportAllocs()
-        b.ResetTimer()
-        for i := 0; i < b.N; i++ {
-                hub.postEvent("bench", "msg")
-        }
+	hub := newEventHub()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hub.postEvent("bench", "msg")
+	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
-	"time"
 )
 
 func init() {
@@ -24,7 +23,6 @@ func newServer() http.Handler {
 	mux.Handle("/", fs)
 	mux.HandleFunc("/ws", serveWS(hub))
 	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -48,8 +46,7 @@ func newServer() http.Handler {
 			return
 		}
 		e := hub.postEvent(tenantID, req.Message)
-		duration := time.Since(start)
-		log.Printf("tenant %s: event posted: %s (took %v)", tenantID, req.Message, duration)
+		log.Printf("tenant %s: event posted: %s (took %s)", tenantID, req.Message, e.Elapsed)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(e)
 	})

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,26 +6,51 @@
     <style>
       body {
         font-family: Arial, sans-serif;
+        background-color: #f9f9f9;
         max-width: 600px;
         margin: 40px auto;
+        padding: 20px;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
       }
       #controls {
         margin-bottom: 10px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
       }
       #events {
         border: 1px solid #ccc;
-        height: 200px;
+        height: 250px;
         overflow-y: auto;
         padding: 0;
         list-style: none;
+        background-color: #fff;
       }
       #events li {
-        padding: 4px;
+        padding: 6px;
         border-bottom: 1px solid #eee;
+        font-size: 14px;
       }
       .highlight {
         background-color: #ffffcc;
         transition: background-color 1s ease;
+      }
+      #eventForm {
+        margin-top: 10px;
+        display: flex;
+        gap: 10px;
+      }
+      #eventForm input {
+        flex: 1;
+        padding: 6px;
+      }
+      button {
+        padding: 6px 12px;
+      }
+      #status {
+        margin-left: auto;
+        font-weight: bold;
       }
     </style>
   </head>
@@ -59,7 +84,8 @@
           const ev = JSON.parse(e.data);
           const li = document.createElement("li");
           const ts = new Date(ev.timestamp).toLocaleTimeString();
-          li.textContent = `${ts} - ${ev.message}`;
+          const took = ev.elapsed ? ` (took ${ev.elapsed})` : "";
+          li.textContent = `${ts} - ${ev.message}${took}`;
           li.classList.add("highlight");
           eventsList.appendChild(li);
           setTimeout(() => li.classList.remove("highlight"), 1000);


### PR DESCRIPTION
## Summary
- improve frontend styling
- display server processing time for each event
- add elapsed field to event struct
- return event with elapsed time from hub
- update server log to use elapsed duration
- introduce GitHub Actions workflow to enforce `gofmt` and run `go test`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688b9848c4548330a3a25bd1b25adf55